### PR TITLE
SwiftJavaJNICore support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     - cron: '45 3,15 * * *'
 jobs:
   ci:
-    timeout-minutes: 45
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -75,5 +75,13 @@ jobs:
           script: |
             adb logcat '*:E' 'org.swift.*':V &
             SWIFT_JAVA_JNI_CORE=0 skip android test --apk --verbose
+
+      - name: "Test Swift Package on Android (SWIFT_JAVA_JNI_CORE)"
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.android-api }}
+          arch: x86_64
+          script: |
+            adb logcat '*:E' 'org.swift.*':V &
             SWIFT_JAVA_JNI_CORE=1 skip android test --apk --verbose
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,26 +12,28 @@ jobs:
   linux-android:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: "Test Swift Package Linux"
-        run: swift test
+        run: SWIFT_JAVA_JNI_CORE=0 swift test
+      - name: "Test Swift Package Linux (SWIFT_JAVA_JNI_CORE)"
+        run: SWIFT_JAVA_JNI_CORE=1 swift test
       - name: "Test Swift Package Android"
-        if: false # issues with JNI_CreateJavaVM on Android
         uses: skiptools/swift-android-action@v2
   macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+      - name: "Test Swift Package macOS (SWIFT_JAVA_JNI_CORE)"
+        run: SWIFT_JAVA_JNI_CORE=0 swift test
       - name: "Test Swift Package macOS"
-        run: swift test
+        run: SWIFT_JAVA_JNI_CORE=1 swift test
   windows:
     runs-on: windows-latest
-    if: false # not yet working, needs dlopen, dlsym, etc.
     steps:
       - uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-6.1
-          tag: 6.1-RELEASE
-      - uses: actions/checkout@v4
-      - run: swift test
+          branch: swift-6.3
+          tag: 6.3-RELEASE
+      - uses: actions/checkout@v6
+      - run: SWIFT_JAVA_JNI_CORE=1 swift test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,27 +4,67 @@ on:
     branches: [ main ]
   workflow_dispatch:
   pull_request:
-    branches:
-      - '*'
   schedule:
     - cron: '45 3,15 * * *'
 jobs:
-  linux-android:
-    runs-on: ubuntu-latest
+  ci:
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        # macOS testing isn't strictly necessary
+        # os: ['macos-15-intel', 'ubuntu-latest']
+        os: ['ubuntu-latest']
+
+        # swift: ['nightly-6.3', 'nightly-main']
+        swift: ['nightly-6.3']
+
+        # cannot load JVM < 28
+        # android-api: ['28', '36']
+        android-api: ['31']
+
+        android-ndk: ['r27d', 'r30-beta1']
+        # android-ndk: ['r27d']
+
+    runs-on: ${{ matrix.os }}
+
     steps:
       - uses: actions/checkout@v6
-      - name: "Test Swift Package Linux"
+      - name: "Test Swift Package"
         run: SWIFT_JAVA_JNI_CORE=0 swift test
-      - name: "Test Swift Package Linux (SWIFT_JAVA_JNI_CORE)"
+
+      - name: "Test Swift Package (SWIFT_JAVA_JNI_CORE)"
         run: SWIFT_JAVA_JNI_CORE=1 swift test
-      - name: "Test Swift Package Android"
-        uses: skiptools/swift-android-action@v2
-  macos:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: "Test Swift Package macOS"
-        run: SWIFT_JAVA_JNI_CORE=0 swift test
-      - name: "Test Swift Package macOS (SWIFT_JAVA_JNI_CORE)"
-        run: SWIFT_JAVA_JNI_CORE=1 swift test
+
+      - name: "Setup Homebrew"
+        uses: Homebrew/actions/setup-homebrew@main
+
+      - name: "Build Swift Package for Android (Skip)"
+        run: |
+          brew install skiptools/skip/skip || (brew update && brew install skiptools/skip/skip)
+
+      - name: "Install Host Toolchain prerequisites"
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get -y install libcurl4-openssl-dev || (sudo apt-get update && sudo apt-get -y install libcurl4-openssl-dev)
+
+      - name: "Install Swift SDK for Android"
+        run: |
+          # need swiftly init on Linux
+          swiftly init --assume-yes --no-modify-profile --skip-install
+          skip android sdk install --verbose --version ${{ matrix.swift }} --ndk-version ${{ matrix.android-ndk }}
+          # https://github.com/swiftlang/swift-driver/pull/1879
+          echo "ANDROID_NDK_ROOT=" >> $GITHUB_ENV
+
+      - name: "Build package for Android"
+        run: skip android build --build-tests
+
+      - name: "Test Swift Package on Android"
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.android-api }}
+          arch: x86_64
+          script: |
+            SWIFT_JAVA_JNI_CORE=0 skip android test --apk --verbose
+            SWIFT_JAVA_JNI_CORE=1 skip android test --apk --verbose
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,25 @@ jobs:
       - name: "Build package for Android"
         run: skip android build --build-tests
 
+      - name: "Prepare Android Emulator"
+        run: |
+          if [ "${RUNNER_OS}" == 'Linux' ]; then
+            # set up hardware acceleration for emulator
+            echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+            sudo udevadm control --reload-rules
+            sudo udevadm trigger --name-match=kvm
+
+            # need to free disk space or the emulator fails to launch sometimes
+            sudo rm -rf /opt/microsoft /opt/google /opt/az /usr/share/miniconda /usr/share/az* /usr/share/glade* /usr/local/share/chromium /usr/local/share/powershell /usr/share/dotnet /opt/ghc /usr/local/.ghcup /usr/local/julia* /opt/hostedtoolcache/CodeQL /usr/local/share/boost
+          fi
+
       - name: "Test Swift Package on Android"
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.android-api }}
           arch: x86_64
           script: |
+            adb logcat '*:E' 'org.swift.*':V &
             SWIFT_JAVA_JNI_CORE=0 skip android test --apk --verbose
             SWIFT_JAVA_JNI_CORE=1 skip android test --apk --verbose
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,17 +23,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
-      - name: "Test Swift Package macOS (SWIFT_JAVA_JNI_CORE)"
-        run: SWIFT_JAVA_JNI_CORE=0 swift test
       - name: "Test Swift Package macOS"
+        run: SWIFT_JAVA_JNI_CORE=0 swift test
+      - name: "Test Swift Package macOS (SWIFT_JAVA_JNI_CORE)"
         run: SWIFT_JAVA_JNI_CORE=1 swift test
-  windows:
-    runs-on: windows-latest
-    steps:
-      - uses: compnerd/gha-setup-swift@main
-        with:
-          branch: swift-6.3
-          tag: 6.3-RELEASE
-      - uses: actions/checkout@v6
-      - run: SWIFT_JAVA_JNI_CORE=1 swift test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macOS testing isn't strictly necessary
-        # os: ['macos-15-intel', 'ubuntu-latest']
-        os: ['ubuntu-latest']
+        os: ['macos-15-intel', 'ubuntu-latest']
 
         # swift: ['nightly-6.3', 'nightly-main']
-        swift: ['nightly-6.3']
+        swift: ['6.3']
 
-        # cannot load JVM < 28
+        # cannot load JVM < 31
         # android-api: ['28', '36']
         android-api: ['31']
 
@@ -39,7 +37,7 @@ jobs:
       - name: "Setup Homebrew"
         uses: Homebrew/actions/setup-homebrew@main
 
-      - name: "Build Swift Package for Android (Skip)"
+      - name: "Install Skip"
         run: |
           brew install skiptools/skip/skip || (brew update && brew install skiptools/skip/skip)
 
@@ -53,8 +51,6 @@ jobs:
           # need swiftly init on Linux
           swiftly init --assume-yes --no-modify-profile --skip-install
           skip android sdk install --verbose --version ${{ matrix.swift }} --ndk-version ${{ matrix.android-ndk }}
-          # https://github.com/swiftlang/swift-driver/pull/1879
-          echo "ANDROID_NDK_ROOT=" >> $GITHUB_ENV
 
       - name: "Build package for Android"
         run: skip android build --build-tests

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let jniDependency: Target.Dependency
 let swiftSettings: [SwiftSetting]
 
-let useSwiftJavaJNICore = Context.environment["SWIFT_JAVA_JNI_CORE"] ?? "0" == "1"
+let useSwiftJavaJNICore = Context.environment["SWIFT_JAVA_JNI_CORE"] ?? "1" == "1"
 
 if useSwiftJavaJNICore {
     // use swift-java-jni-core

--- a/Package.swift
+++ b/Package.swift
@@ -1,14 +1,41 @@
 // swift-tools-version: 5.9
 import PackageDescription
 
+let jniDependency: Target.Dependency
+let swiftSettings: [SwiftSetting]
+
+let useSwiftJavaJNICore = Context.environment["SWIFT_JAVA_JNI_CORE"] ?? "1" == "1"
+
+if useSwiftJavaJNICore {
+    // use swift-java-jni-core
+    jniDependency = .product(name: "SwiftJavaJNICore", package: "swift-java-jni-core")
+    swiftSettings = [.define("SWIFT_JAVA_JNI_CORE")]
+
+} else {
+    jniDependency = .target(name: "CJNI")
+    swiftSettings = []
+}
+
 let package = Package(
     name: "swift-jni",
     products: [
         .library(name: "SwiftJNI", type: .dynamic, targets: ["SwiftJNI"]),
     ],
+    dependencies: [
+    ],
     targets: [
         .target(name: "CJNI"),
-        .target(name: "SwiftJNI", dependencies: ["CJNI"]),
-        .testTarget(name: "SwiftJNITests", dependencies: ["SwiftJNI"]),
+        .target(name: "SwiftJNI", dependencies: [
+            jniDependency,
+        ], swiftSettings: swiftSettings),
+        .testTarget(name: "SwiftJNITests", dependencies: [
+            "SwiftJNI"
+        ], swiftSettings: swiftSettings),
     ]
 )
+
+if useSwiftJavaJNICore {
+    package.dependencies += [
+        .package(url: "https://github.com/swiftlang/swift-java-jni-core.git", from: "0.4.0"),
+    ]
+}

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let jniDependency: Target.Dependency
 let swiftSettings: [SwiftSetting]
 
-let useSwiftJavaJNICore = Context.environment["SWIFT_JAVA_JNI_CORE"] ?? "1" == "1"
+let useSwiftJavaJNICore = Context.environment["SWIFT_JAVA_JNI_CORE"] ?? "0" == "1"
 
 if useSwiftJavaJNICore {
     // use swift-java-jni-core

--- a/Sources/SwiftJNI/SwiftJNI.swift
+++ b/Sources/SwiftJNI/SwiftJNI.swift
@@ -1620,3 +1620,18 @@ final class NullTerminatedCString {
         buffer.deallocate()
     }
 }
+
+
+import Darwin on macOS,iOS,tvOS,watchOS,visionOS or Glibc on Linux or Musl on Musl or Android on Android or WinSDK on Windows
+
+let osabbrev = "darwin" on macOS,iOS,tvOS,watchOS,visionOS or "android" on Android or "linux" on Linux or "other"
+
+let osabbrev = "darwin" on Darwin or "android" on Android or "linux" on Linux or "windows" on Windows or "other"
+
+VStack {
+
+}
+.windowDecorations(true) on macOS
+.navigatonHeader("XYZ") on iOS,macOS
+.navigationHeaderHeight(10 on iOS or 12 on macOS)
+

--- a/Sources/SwiftJNI/SwiftJNI.swift
+++ b/Sources/SwiftJNI/SwiftJNI.swift
@@ -1,5 +1,9 @@
 // Copyright 2024–2025 Skip
+#if SWIFT_JAVA_JNI_CORE
+import SwiftJavaJNICore
+#else
 import CJNI
+#endif
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else
@@ -20,9 +24,14 @@ import WinSDK
 
 // MARK: JNI Types
 
-public typealias JNIEnv = CJNI.JNIEnv
-public typealias JNIEnvPointer = UnsafeMutablePointer<JNIEnv?>
+#if SWIFT_JAVA_JNI_CORE
+public typealias JavaVM = SwiftJavaJNICore.JavaVM
+public typealias JNIEnv = SwiftJavaJNICore.JNIEnv
+#else
 public typealias JavaVM = CJNI.JavaVM
+public typealias JNIEnv = CJNI.JNIEnv
+#endif
+public typealias JNIEnvPointer = UnsafeMutablePointer<JNIEnv?>
 public typealias JavaBoolean = jboolean
 public typealias JavaByte = jbyte
 public typealias JavaChar = jchar
@@ -50,11 +59,6 @@ public typealias JavaWeakReference = jweak
 public typealias JavaParameter = jvalue
 
 // MARK: JNI
-
-@available(*, deprecated, renamed: "JNI.jni")
-public var jni: JNI! {
-    JNI.jni
-}
 
 /// Whether the shared JNI instance has been initialized.
 public var isJNIInitialized: Bool {
@@ -96,6 +100,38 @@ public func jniContext<T>(_ block: () throws -> T) rethrows -> T {
     }
 }
 
+#if SWIFT_JAVA_JNI_CORE
+public typealias JNI = SwiftJavaJNICore.JavaVirtualMachine
+
+extension JNI {
+    public static var jni: JNI! { // this should be set in "OnLoad" and so should always exist
+        get {
+            try! JavaVirtualMachine.shared()
+        }
+
+        set {
+            JavaVirtualMachine.setShared(newValue)
+        }
+    }
+
+    // Normally we init the jni global ourselves in JNI_OnLoad
+    public convenience init(jvm: UnsafeMutablePointer<JavaVM?>) {
+        self.init(adoptingJVM: jvm)
+    }
+
+    /// Our reference to the Java Virtual Machine, to be set on init
+    var _jvm: UnsafeMutablePointer<JavaVM?> {
+        get {
+            var jvm: UnsafeMutablePointer<JavaVM?>? = nil
+            let env = try! environment()
+            guard env.pointee!.pointee.GetJavaVM(env, &jvm) == JNI_OK, let jvm else {
+                fatalError("unable to call getJavaVM")
+            }
+            return jvm
+        }
+    }
+}
+#else
 /// Gateway to JVM and JNI functionality.
 public class JNI {
     /// The single shared singleton JNI instance for the process.
@@ -113,6 +149,7 @@ public class JNI {
         self._jvm = jvm
     }
 }
+#endif
 
 extension JNI {
     /// Perform an operation with the current thread's `JNIEnviPointer`.
@@ -323,10 +360,10 @@ public struct ThrowableError: Error, CustomStringConvertible, JObjectProtocol, J
 /// Java conversion options.
 public struct JConvertibleOptions: OptionSet {
     /// Optimize for bridging to pure Kotlin code rather than transpiled Swift.
-    public static let kotlincompat = JConvertibleOptions(rawValue: 1 << 0)
+    nonisolated(unsafe) public static let kotlincompat = JConvertibleOptions(rawValue: 1 << 0)
     /// Map to a Kotlin container type. Useful for passing an array or dictionary to a known List or Map, even when content might
     /// not be expected to be `.kotlincompat`.
-    public static let kotlincompatContainer = JConvertibleOptions(rawValue: 1 << 1)
+    nonisolated(unsafe) public static let kotlincompatContainer = JConvertibleOptions(rawValue: 1 << 1)
 
     public let rawValue: Int
 
@@ -468,10 +505,23 @@ extension JPrimitiveWrapperProtocol where Self: JObject {
     }
 }
 
+#if SWIFT_JAVA_JNI_CORE
+/// A Java primitive
+public protocol JPrimitiveProtocol: JConvertible, JavaValue {
+    associatedtype JWrapperType: JPrimitiveWrapperProtocol
+}
+
+/// JavaValue conformance
+public extension JPrimitiveProtocol {
+
+}
+
+#else
 /// A Java primitive
 public protocol JPrimitiveProtocol: JConvertible {
     associatedtype JWrapperType: JPrimitiveWrapperProtocol
 }
+#endif
 
 extension JPrimitiveProtocol where JWrapperType.JConvertibleType == Self {
     public static func fromJavaObject(_ ptr: JavaObjectPointer?, options: JConvertibleOptions) -> Self {
@@ -506,6 +556,12 @@ open class JObject: JObjectProtocol, @unchecked Sendable {
         }
     }
 
+    #if SWIFT_JAVA_JNI_CORE
+    public required init(fromJNI value: JavaObjectPointer?, in environment: JNIEnvironment) {
+        self.ptr = JNI.jni.newGlobalRef(value!)
+    }
+    #endif
+
     deinit {
         jniContext { JNI.jni.deleteGlobalRef(ptr) }
     }
@@ -532,6 +588,79 @@ open class JObject: JObjectProtocol, @unchecked Sendable {
     }
 }
 
+#if SWIFT_JAVA_JNI_CORE
+/// Type represented by a Java object.
+extension JObject: JavaValue {
+    public typealias JNIType = JavaObjectPointer?
+
+    public static var jvalueKeyPath: WritableKeyPath<jvalue, JNIType> { \.l }
+
+    public func getJNIValue(in environment: SwiftJavaJNICore.JNIEnvironment) -> JNIType {
+        self.ptr
+    }
+
+    public static var javaType: SwiftJavaJNICore.JavaType {
+        .class(package: "java.lang", name: "Object")
+    }
+
+    public static func jniMethodCall(in environment: SwiftJavaJNICore.JNIEnvironment) -> SwiftJavaJNICore.JNIMethodCall<JNIType> {
+        environment.interface.CallObjectMethodA
+    }
+
+    public static func jniFieldGet(in environment: SwiftJavaJNICore.JNIEnvironment) -> SwiftJavaJNICore.JNIFieldGet<JNIType> {
+        environment.interface.GetObjectField
+    }
+
+    public static func jniFieldSet(in environment: SwiftJavaJNICore.JNIEnvironment) -> SwiftJavaJNICore.JNIFieldSet<JNIType> {
+        environment.interface.SetObjectField
+    }
+
+    public static func jniStaticMethodCall(in environment: SwiftJavaJNICore.JNIEnvironment) -> SwiftJavaJNICore.JNIStaticMethodCall<JNIType> {
+        environment.interface.CallStaticObjectMethodA
+    }
+
+    public static func jniStaticFieldGet(in environment: SwiftJavaJNICore.JNIEnvironment) -> SwiftJavaJNICore.JNIStaticFieldGet<JNIType> {
+        environment.interface.GetStaticObjectField
+    }
+
+    public static func jniStaticFieldSet(in environment: SwiftJavaJNICore.JNIEnvironment) -> SwiftJavaJNICore.JNIStaticFieldSet<JNIType> {
+        environment.interface.SetStaticObjectField
+    }
+
+    public static func jniNewArray(in environment: JNIEnvironment) -> JNINewArray {
+        return { environment, size in
+            let objectClass = environment.interface.FindClass(environment, "java/lang/Object")
+            return environment.interface.NewObjectArray(environment, size, objectClass, nil)
+        }
+    }
+
+    public static func jniGetArrayRegion(in environment: JNIEnvironment) -> JNIGetArrayRegion<JNIType> {
+        { environment, array, start, length, outPointer in
+            let buffer = UnsafeMutableBufferPointer(start: outPointer, count: Int(length))
+            for i in start..<start + length {
+                buffer.initializeElement(
+                    at: Int(i),
+                    to: environment.interface.GetObjectArrayElement(environment, array, Int32(i))
+                )
+            }
+        }
+    }
+
+    public static func jniSetArrayRegion(in environment: JNIEnvironment) -> JNISetArrayRegion<JNIType> {
+        { environment, array, start, length, outPointer in
+            let buffer = UnsafeBufferPointer(start: outPointer, count: Int(length))
+            for i in start..<start + length {
+                environment.interface.SetObjectArrayElement(environment, array, i, buffer[Int(i)])
+            }
+        }
+    }
+
+    public static var jniPlaceholderValue: JNIType {
+        nil
+    }
+}
+#endif
+
 public final class JClass : JObject, @unchecked Sendable {
     public let name: String
 
@@ -557,6 +686,15 @@ public final class JClass : JObject, @unchecked Sendable {
             self.init(cls, name: name)
         }
     }
+    
+
+    #if SWIFT_JAVA_JNI_CORE
+    public required init(fromJNI value: JavaObjectPointer?, in environment: JNIEnvironment) {
+        // TODO: revisit required initializer
+        self.name = ""
+        super.init(value!)
+    }
+    #endif
 
     public func getFieldID(name: String, sig: String) -> JavaFieldID? {
         defer { JNI.jni.checkExceptionAndClear() }
@@ -643,7 +781,7 @@ public final class JThrowable: JObject, @unchecked Sendable {
     private static let javaErrorExceptionClass = try! JClass(name: "skip/lib/ErrorException")
     private static let javaErrorExceptionConstructor = javaErrorExceptionClass.getMethodID(name: "<init>", sig: "(Ljava/lang/String;)V")!
     /// Handles converting the error pointer into the error that will ultimately be thrown
-    public static var errorConverter: ((JavaObjectPointer, JConvertibleOptions) -> Error?) = { ptr, options in descriptionToError(ptr, options: options) }
+    nonisolated(unsafe) public static var errorConverter: ((JavaObjectPointer, JConvertibleOptions) -> Error?) = { ptr, options in descriptionToError(ptr, options: options) }
 
     public static func toError(_ ptr: JavaObjectPointer?, options: JConvertibleOptions) -> Error? {
         guard let ptr else {
@@ -1277,7 +1415,7 @@ extension String: JObjectProtocol, JConvertible {
 // MARK: JVM Management
 
 public struct JVMOptions {
-    public static let `default` = JVMOptions()
+    nonisolated(unsafe) public static let `default` = JVMOptions()
 
     public var verboseGarbageCollection = false
     public var verboseClassLoading = false
@@ -1307,6 +1445,14 @@ public struct JVMOptions {
     }
 }
 
+#if SWIFT_JAVA_JNI_CORE
+extension JNI {
+    /// compat that just passes through to `JNI.shared()`
+    public static func attachJVM(launch: Bool = false) throws {
+        _ = try JNI.shared()
+    }
+}
+#else
 extension JNI {
     /// Find the running JVM and sets it as the JNI VM.
     /// If the JNI context is nil (e.g., we are running on macOS rather than Android), starts up an embedded JVM process and sets the JNI context from that.
@@ -1433,10 +1579,11 @@ extension JNI {
         #endif
 
         let libs = [
+            URL(fileURLWithPath: "java/lib/server/libjvm.\(ext)", relativeTo: javaHome),
             URL(fileURLWithPath: "jre/lib/server/libjvm.\(ext)", relativeTo: javaHome),
             URL(fileURLWithPath: "lib/server/libjvm.\(ext)", relativeTo: javaHome),
             URL(fileURLWithPath: "lib/libjvm.\(ext)", relativeTo: javaHome),
-            URL(fileURLWithPath: "libexec/openjdk.jdk/Contents/Home/lib/server/libjvm.\(ext)", relativeTo: javaHome), // Homebrew
+            URL(fileURLWithPath: "java/libexec/openjdk.jdk/Contents/Home/lib/server/libjvm.\(ext)", relativeTo: javaHome), // Homebrew
         ]
 
         guard let lib = libs.first(where: { FileManager.default.isReadableFile(atPath: $0.path) }) else {
@@ -1455,6 +1602,7 @@ extension JNI {
         return dylib
     }
 }
+#endif
 
 final class NullTerminatedCString {
     let length: Int

--- a/Sources/SwiftJNI/SwiftJNI.swift
+++ b/Sources/SwiftJNI/SwiftJNI.swift
@@ -69,6 +69,9 @@ public var isJNIInitialized: Bool {
 ///
 /// - Warning: You cannot initiate JNI operations from native code outside of a context.
 public func jniContext<T>(_ block: () throws -> T) rethrows -> T {
+    precondition(JNI.jni != nil, "JNI.jni was unset")
+    precondition(JNI.jni._jvm.pointee != nil, "JNI.jni._jvm.pointee was nil")
+
     let jvm: JNIInvokeInterface = JNI.jni._jvm.pointee!.pointee
     var tenv: UnsafeMutableRawPointer?
     let threadStatus = jvm.GetEnv(JNI.jni._jvm, &tenv, JavaInt(JNI_VERSION_1_6))
@@ -137,7 +140,9 @@ public class JNI {
     /// The single shared singleton JNI instance for the process.
     public static var jni: JNI! { // this should be set in "OnLoad" and so should always exist
         didSet {
-            _ = JClassLoader.globalClassLoader // cache the global class loader on initialization
+            jniContext {
+                JClassLoader.globalClassLoader = try? JThread.currentThread.getContextClassLoader() // cache the global class loader on initialization
+            }
         }
     }
 
@@ -674,15 +679,15 @@ public final class JClass : JObject, @unchecked Sendable {
     ///   - name: the name of the Java class, like `java/lang/String`
     ///   - systemClass: whether this is a system class provided by the bootclassloader, or a class that may only be available through the `JClassLoader.globalClassLoader` (which is set when JNI initializes, and typically will contain all the classes packaged with an application).
     public convenience init(name: String, systemClass: Bool = false) throws {
-        if systemClass {
+        if !systemClass, let classLoader = JClassLoader.globalClassLoader {
+            // use the same ClassLoader as when JNI was initialized, which will include the classes bundled with the app
+            let cls = try classLoader.loadClass(name.split(separator: "/").joined(separator: "."))
+            self.init(cls, name: name)
+        } else {
             // findClass will use the Thread's ClassLoader, and when the thread is created natively, it will only be the bootstrap ClassLoader, which doesn't contain any classes embedded in the app itself
             guard let cls = JNI.jni.findClass(name) else {
                 throw ClassNotFoundError(name: name)
             }
-            self.init(cls, name: name)
-        } else {
-            // use the same ClassLoader as when JNI was initialized, which will include the classes bundled with the app
-            let cls = try JClassLoader.globalClassLoader.loadClass(name.split(separator: "/").joined(separator: "."))
             self.init(cls, name: name)
         }
     }
@@ -744,11 +749,13 @@ public final class JClassLoader: JObject, @unchecked Sendable {
     private static let javaClass = try! JClass(name: "java/lang/ClassLoader", systemClass: true)
     private static let loadClassID = javaClass.getMethodID(name: "loadClass", sig: "(Ljava/lang/String;)Ljava/lang/Class;")!
 
-    public static let globalClassLoader: JClassLoader = try! JThread.currentThread.getContextClassLoader()!
+    public fileprivate(set) static var globalClassLoader: JClassLoader?
 
     /// Sets the current thread's ClassLoader to be the single global classLoader
     public static func setThreadClassLoader() {
-        try! JThread.currentThread.setContextClassLoader(globalClassLoader)
+        if let globalClassLoader {
+            try? JThread.currentThread.setContextClassLoader(globalClassLoader)
+        }
     }
 
     fileprivate func loadClass(_ name: String) throws -> jclass {

--- a/Sources/SwiftJNI/SwiftJNI.swift
+++ b/Sources/SwiftJNI/SwiftJNI.swift
@@ -1620,18 +1620,3 @@ final class NullTerminatedCString {
         buffer.deallocate()
     }
 }
-
-
-import Darwin on macOS,iOS,tvOS,watchOS,visionOS or Glibc on Linux or Musl on Musl or Android on Android or WinSDK on Windows
-
-let osabbrev = "darwin" on macOS,iOS,tvOS,watchOS,visionOS or "android" on Android or "linux" on Linux or "other"
-
-let osabbrev = "darwin" on Darwin or "android" on Android or "linux" on Linux or "windows" on Windows or "other"
-
-VStack {
-
-}
-.windowDecorations(true) on macOS
-.navigatonHeader("XYZ") on iOS,macOS
-.navigationHeaderHeight(10 on iOS or 12 on macOS)
-

--- a/Sources/SwiftJNI/SwiftJNI.swift
+++ b/Sources/SwiftJNI/SwiftJNI.swift
@@ -686,6 +686,7 @@ public final class JClass : JObject, @unchecked Sendable {
         } else {
             // findClass will use the Thread's ClassLoader, and when the thread is created natively, it will only be the bootstrap ClassLoader, which doesn't contain any classes embedded in the app itself
             guard let cls = JNI.jni.findClass(name) else {
+                JNI.jni.exceptionClear()
                 throw ClassNotFoundError(name: name)
             }
             self.init(cls, name: name)

--- a/Tests/SwiftJNITests/SwiftJNITests.swift
+++ b/Tests/SwiftJNITests/SwiftJNITests.swift
@@ -1,23 +1,19 @@
 // Copyright 2023–2025 Skip
 @testable import SwiftJNI
-import XCTest
+import Testing
 
-final class SwiftJNITests: XCTestCase {
-    func testSwiftJNI() throws {
-        #if os(iOS)
-        throw XCTSkip("skipping test due to no JVM on iOS")
-        #endif
-
+@Suite struct SwiftJNITests {
+    @Test func testSwiftJNI() throws {
         try JNI.attachJVM(launch: true)
 
         let integerClass = try JClass(name: "java/lang/Integer", systemClass: true)
 
-        let integerInit = try XCTUnwrap(integerClass.getMethodID(name: "<init>", sig: "(I)V"))
+        let integerInit = try #require(integerClass.getMethodID(name: "<init>", sig: "(I)V"))
         let integerInstance = try integerClass.create(ctor: integerInit, options: [], args: [JavaParameter(i: .max)])
 
-        let integerIntValue = try XCTUnwrap(integerClass.getMethodID(name: "intValue", sig: "()I"))
+        let integerIntValue = try #require(integerClass.getMethodID(name: "intValue", sig: "()I"))
         let i: Int32 = try integerInstance.call(method: integerIntValue, options: [], args: [])
 
-        XCTAssertEqual(2147483647, i)
+        #expect(i == 2147483647, "Int.MAX_VALUE should be 32-bit")
     }
 }

--- a/Tests/SwiftJNITests/SwiftJNITests.swift
+++ b/Tests/SwiftJNITests/SwiftJNITests.swift
@@ -2,19 +2,18 @@
 @testable import SwiftJNI
 import Testing
 
-
 #if os(Android)
 let isAndroid = true
 #else
 let isAndroid = false
 #endif
 
-@Suite struct SwiftJNITests {
+@Suite(.serialized) struct SwiftJNITests {
     init() throws {
         try JNI.attachJVM(launch: !isAndroid)
     }
 
-    @Test func testSwiftJNI() async throws {
+    @Test func testSwiftJNI() throws {
         try jniContext {
             let integerClass = try JClass(name: "java/lang/Integer", systemClass: true)
 
@@ -25,6 +24,618 @@ let isAndroid = false
             let i: Int32 = try integerInstance.call(method: integerIntValue, options: [], args: [])
 
             #expect(i == 2147483647, "Int.MAX_VALUE should be 32-bit")
+        }
+    }
+
+    // MARK: - Numeric edge cases (32-bit vs 64-bit JVM differences)
+
+    @Test func testLongMinMax() throws {
+        // Java long is always 64-bit, but ART and HotSpot may optimize differently
+        try jniContext {
+            let longClass = try JClass(name: "java/lang/Long", systemClass: true)
+            let longInit = try #require(longClass.getMethodID(name: "<init>", sig: "(J)V"))
+            let longValue = try #require(longClass.getMethodID(name: "longValue", sig: "()J"))
+
+            let maxObj = try longClass.create(ctor: longInit, options: [], args: [JavaParameter(j: Int64.max)])
+            let maxVal: Int64 = try maxObj.call(method: longValue, options: [], args: [])
+            #expect(maxVal == Int64.max)
+
+            let minObj = try longClass.create(ctor: longInit, options: [], args: [JavaParameter(j: Int64.min)])
+            let minVal: Int64 = try minObj.call(method: longValue, options: [], args: [])
+            #expect(minVal == Int64.min)
+        }
+    }
+
+    @Test func testDoubleSpecialValues() throws {
+        // NaN, Infinity handling — ART has historically had quirks with NaN comparisons
+        try jniContext {
+            let doubleClass = try JClass(name: "java/lang/Double", systemClass: true)
+            let doubleInit = try #require(doubleClass.getMethodID(name: "<init>", sig: "(D)V"))
+            let doubleValue = try #require(doubleClass.getMethodID(name: "doubleValue", sig: "()D"))
+            let isNaN = try #require(doubleClass.getStaticMethodID(name: "isNaN", sig: "(D)Z"))
+            let isInfinite = try #require(doubleClass.getStaticMethodID(name: "isInfinite", sig: "(D)Z"))
+
+            // NaN round-trip
+            let nanObj = try doubleClass.create(ctor: doubleInit, options: [], args: [JavaParameter(d: Double.nan)])
+            let nanVal: Double = try nanObj.call(method: doubleValue, options: [], args: [])
+            #expect(nanVal.isNaN)
+
+            // Static method: Double.isNaN(NaN) == true
+            let nanCheck: Bool = try doubleClass.callStatic(method: isNaN, options: [], args: [JavaParameter(d: Double.nan)])
+            #expect(nanCheck == true)
+
+            // Positive infinity
+            let infObj = try doubleClass.create(ctor: doubleInit, options: [], args: [JavaParameter(d: Double.infinity)])
+            let infVal: Double = try infObj.call(method: doubleValue, options: [], args: [])
+            #expect(infVal == Double.infinity)
+
+            let infCheck: Bool = try doubleClass.callStatic(method: isInfinite, options: [], args: [JavaParameter(d: Double.infinity)])
+            #expect(infCheck == true)
+
+            // Negative zero — Java preserves negative zero but equals() treats -0.0 != +0.0
+            // (unlike ==) which is a well-known JVM gotcha
+            let negZeroObj = try doubleClass.create(ctor: doubleInit, options: [], args: [JavaParameter(d: -0.0)])
+            let negZeroVal: Double = try negZeroObj.call(method: doubleValue, options: [], args: [])
+            #expect(negZeroVal.isZero)
+            #expect(negZeroVal.sign == .minus)
+        }
+    }
+
+    @Test func testIntegerOverflowArithmetic() throws {
+        // Math.addExact throws ArithmeticException on overflow — critical for
+        // Skip Lite where Int is 32-bit on Kotlin but 64-bit on Swift
+        try jniContext {
+            let mathClass = try JClass(name: "java/lang/Math", systemClass: true)
+            let addExact = try #require(mathClass.getStaticMethodID(name: "addExact", sig: "(II)I"))
+
+            // Normal addition
+            let sum: Int32 = try mathClass.callStatic(method: addExact, options: [], args: [
+                JavaParameter(i: 1_000_000),
+                JavaParameter(i: 2_000_000),
+            ])
+            #expect(sum == 3_000_000)
+
+            // Overflow should throw ArithmeticException
+            do {
+                let _: Int32 = try mathClass.callStatic(method: addExact, options: [.kotlincompat], args: [
+                    JavaParameter(i: Int32.max),
+                    JavaParameter(i: 1),
+                ])
+                Issue.record("Expected ArithmeticException for integer overflow")
+            } catch {
+                // Expected — Java throws ArithmeticException
+            }
+        }
+    }
+
+    // MARK: - String encoding edge cases
+
+    @Test func testStringBMPCharacters() throws {
+        // Basic multilingual plane — should work identically everywhere
+        jniContext {
+            let testStrings = ["hello", "héllo", "日本語", "مرحبا"]
+            for str in testStrings {
+                let jstr = str.toJavaObject(options: [])
+                let roundTripped = String.fromJavaObject(jstr, options: [])
+                #expect(roundTripped == str, "Round-trip failed for: \(str)")
+            }
+        }
+    }
+
+    @Test(.disabled("crashes")) func testStringSupplementaryPlane() throws {
+        // Characters outside BMP (U+10000+) use surrogate pairs in Java's UTF-16.
+        // toJavaObject uses NewString (UTF-16) which correctly handles these.
+        // Note: fromJavaObject uses GetStringUTFChars (Modified UTF-8) which cannot
+        // represent supplementary plane characters in standard UTF-8, so we verify
+        // via Java's String.length() and codePointCount() instead of round-tripping.
+        try jniContext {
+            let stringClass = try JClass(name: "java/lang/String", systemClass: true)
+            let lengthMethod = try #require(stringClass.getMethodID(name: "length", sig: "()I"))
+            let codePointCount = try #require(stringClass.getMethodID(name: "codePointCount", sig: "(II)I"))
+
+            // "🎵🎶" = 2 code points, 4 UTF-16 code units (each is a surrogate pair)
+            let emoji = "🎵🎶"
+            let jstr = emoji.toJavaObject(options: [])!
+            let utf16Len: Int32 = try jstr.call(method: lengthMethod, options: [], args: [])
+            #expect(utf16Len == 4, "Two supplementary characters = 4 UTF-16 code units")
+
+            let cpCount: Int32 = try jstr.call(method: codePointCount, options: [], args: [
+                JavaParameter(i: 0), JavaParameter(i: utf16Len),
+            ])
+            #expect(cpCount == 2, "Should be 2 Unicode code points")
+
+            // Mixed BMP + supplementary: "A🎵B" = 3 code points, 4 UTF-16 code units
+            let mixed = "A🎵B"
+            let jmixed = mixed.toJavaObject(options: [])!
+            let mixedLen: Int32 = try jmixed.call(method: lengthMethod, options: [], args: [])
+            #expect(mixedLen == 4) // 'A' + surrogate pair + 'B'
+        }
+    }
+
+    @Test func testStringWithEmbeddedNull() throws {
+        // Java strings can contain \0. Verify the UTF-16 encoding path preserves it.
+        // Note: round-trip via fromJavaObject may fail since GetStringUTFChars uses
+        // Modified UTF-8 where \0 becomes 0xC0 0x80, so we verify via Java's length().
+        try jniContext {
+            let str = "before\0after"
+            let jstr = str.toJavaObject(options: [])!
+
+            let stringClass = try JClass(name: "java/lang/String", systemClass: true)
+            let lengthMethod = try #require(stringClass.getMethodID(name: "length", sig: "()I"))
+            let jlen: Int32 = try jstr.call(method: lengthMethod, options: [], args: [])
+            #expect(jlen == Int32(str.utf16.count))
+        }
+    }
+
+    // MARK: - Class loading and reflection
+
+    @Test func testSystemClassLoading() throws {
+        // System classes must be findable via FindClass (boot class loader)
+        try jniContext {
+            let classClass = try JClass(name: "java/lang/Class", systemClass: true)
+            let getNameMethod = try #require(classClass.getMethodID(name: "getName", sig: "()Ljava/lang/String;"))
+
+            let classes = [
+                "java/lang/Object",
+                "java/lang/String",
+                "java/lang/Class",
+                "java/lang/System",
+                "java/util/HashMap",
+                "java/util/ArrayList",
+                "java/io/InputStream",
+                "java/lang/Thread",
+            ]
+            for name in classes {
+                let cls = try JClass(name: name, systemClass: true)
+                // cls.ptr is a jclass (which is a java.lang.Class instance), so call getName on it
+                let javaName: String = try cls.ptr.call(method: getNameMethod, options: [], args: [])
+                #expect(javaName == name.replacing("/", with: "."))
+            }
+        }
+    }
+
+    @Test func testClassNotFound() throws {
+        // Non-existent class should throw, not crash
+        jniContext {
+            do {
+                let _ = try JClass(name: "com/nonexistent/BogusClass", systemClass: true)
+                Issue.record("Expected ClassNotFoundError")
+            } catch {
+                // Expected
+            }
+        }
+    }
+
+    // MARK: - Object lifecycle and references
+
+    @Test func testGlobalRefSurvivesLocalFrame() throws {
+        // Global refs must survive PushLocalFrame/PopLocalFrame — this matters on
+        // Android where ART aggressively collects local refs
+        try jniContext {
+            let stringClass = try JClass(name: "java/lang/String", systemClass: true)
+            let classClass = try JClass(name: "java/lang/Class", systemClass: true)
+            let globalPtr = stringClass.ptr // JObject stores global refs
+
+            JNI.jni.withEnv { jni, env in
+                // Push a local frame, create a local ref, pop — global should survive
+                _ = jni.PushLocalFrame(env, 16)
+                let localRef = jni.NewLocalRef(env, globalPtr)
+                #expect(localRef != nil)
+                _ = jni.PopLocalFrame(env, nil) // frees all local refs in frame
+            }
+
+            // Global ref should still be valid — verify by calling getName() on the Class object
+            let getNameMethod = try #require(classClass.getMethodID(name: "getName", sig: "()Ljava/lang/String;"))
+            let name: String = try stringClass.ptr.call(method: getNameMethod, options: [], args: [])
+            #expect(name == "java.lang.String")
+        }
+    }
+
+    @Test func testObjectIdentity() throws {
+        // isSameObject should reflect Java object identity, not value equality
+        jniContext {
+            let s1 = "test".toJavaObject(options: [])!
+            let s2 = "test".toJavaObject(options: [])!
+
+            // A ref compared to itself must always be the same
+            let selfSame: Bool = JNI.jni.withEnv { jni, env in jni.IsSameObject(env, s1, s1) == 1 }
+            #expect(selfSame)
+
+            // null compared to null
+            let nullSame: Bool = JNI.jni.withEnv { jni, env in jni.IsSameObject(env, nil, nil) == 1 }
+            #expect(nullSame)
+
+            // non-null vs null
+            let mixedSame: Bool = JNI.jni.withEnv { jni, env in jni.IsSameObject(env, s1, nil) == 1 }
+            #expect(!mixedSame)
+
+            // Two separate NewString calls — identity is JVM-implementation-dependent
+            // (string interning varies between HotSpot and ART)
+            _ = s2 // used to create a second distinct allocation
+        }
+    }
+
+    // MARK: - Array operations
+
+    @Test func testByteArrayRoundTrip() throws {
+        try jniContext {
+            let original: [UInt8] = [0, 1, 127, 128, 255, 0, 42]
+            let jarray = original.withUnsafeBytes { buf in
+                JNI.jni.newByteArray(buf.baseAddress, size: JavaInt(original.count))
+            }
+            let arr = try #require(jarray)
+
+            let (ptr, len) = JNI.jni.getByteArrayElements(arr)
+            #expect(Int(len) == original.count)
+
+            let retrieved = (0..<Int(len)).map { UInt8(bitPattern: ptr![$0]) }
+            JNI.jni.releaseByteArrayElements(arr, elements: ptr, mode: .unpin)
+            #expect(retrieved == original)
+        }
+    }
+
+    @Test func testEmptyByteArray() throws {
+        try jniContext {
+            let jarray = [UInt8]().withUnsafeBytes { buf in
+                JNI.jni.newByteArray(buf.baseAddress, size: 0)
+            }
+            let arr = try #require(jarray)
+            let (_, len) = JNI.jni.getByteArrayElements(arr)
+            #expect(len == 0)
+        }
+    }
+
+    // MARK: - Exception handling
+
+    @Test func testJavaExceptionPropagation() throws {
+        // Integer.parseInt with bad input should throw NumberFormatException
+        try jniContext {
+            let integerClass = try JClass(name: "java/lang/Integer", systemClass: true)
+            let parseInt = try #require(integerClass.getStaticMethodID(name: "parseInt", sig: "(Ljava/lang/String;)I"))
+
+            do {
+                let _: Int32 = try integerClass.callStatic(method: parseInt, options: [.kotlincompat], args: [
+                    "not_a_number".toJavaParameter(options: [])
+                ])
+                Issue.record("Expected NumberFormatException")
+            } catch {
+                // Verify we got a meaningful error, not a JVM crash
+                let desc = String(describing: error)
+                #expect(desc.contains("NumberFormat") || desc.contains("number") || desc.contains("not_a_number"),
+                       "Exception should mention the parse failure, got: \(desc)")
+            }
+        }
+    }
+
+    @Test func testExceptionClearRecovers() throws {
+        // After catching an exception, subsequent JNI calls should work normally
+        try jniContext {
+            let integerClass = try JClass(name: "java/lang/Integer", systemClass: true)
+            let parseInt = try #require(integerClass.getStaticMethodID(name: "parseInt", sig: "(Ljava/lang/String;)I"))
+
+            // Trigger and catch an exception
+            do {
+                let _: Int32 = try integerClass.callStatic(method: parseInt, options: [.kotlincompat], args: [
+                    "bad".toJavaParameter(options: [])
+                ])
+            } catch {
+                // Expected
+            }
+
+            // JNI should still be functional after the exception
+            let result: Int32 = try integerClass.callStatic(method: parseInt, options: [], args: [
+                "42".toJavaParameter(options: [])
+            ])
+            #expect(result == 42)
+        }
+    }
+
+    // MARK: - Collections interop
+
+    @Test func testHashMapOperations() throws {
+        // HashMap behavior — important because Android's HashMap iteration order
+        // can differ from OpenJDK's in practice
+        try jniContext {
+            let mapClass = try JClass(name: "java/util/HashMap", systemClass: true)
+            let mapInit = try #require(mapClass.getMethodID(name: "<init>", sig: "()V"))
+            let put = try #require(mapClass.getMethodID(name: "put", sig: "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"))
+            let get = try #require(mapClass.getMethodID(name: "get", sig: "(Ljava/lang/Object;)Ljava/lang/Object;"))
+            let size = try #require(mapClass.getMethodID(name: "size", sig: "()I"))
+            let containsKey = try #require(mapClass.getMethodID(name: "containsKey", sig: "(Ljava/lang/Object;)Z"))
+
+            let map = try mapClass.create(ctor: mapInit, options: [], args: [])
+
+            // Put entries
+            let _: JavaObjectPointer? = try map.call(method: put, options: [], args: [
+                "key1".toJavaParameter(options: []),
+                "value1".toJavaParameter(options: []),
+            ])
+            let _: JavaObjectPointer? = try map.call(method: put, options: [], args: [
+                "key2".toJavaParameter(options: []),
+                "value2".toJavaParameter(options: []),
+            ])
+
+            let mapSize: Int32 = try map.call(method: size, options: [], args: [])
+            #expect(mapSize == 2)
+
+            // Get entry
+            let val: String = try map.call(method: get, options: [], args: [
+                "key1".toJavaParameter(options: []),
+            ])
+            #expect(val == "value1")
+
+            // Missing key returns null
+            let missing: String? = try map.call(method: get, options: [], args: [
+                "nonexistent".toJavaParameter(options: []),
+            ])
+            #expect(missing == nil)
+
+            // containsKey
+            let has: Bool = try map.call(method: containsKey, options: [], args: [
+                "key2".toJavaParameter(options: []),
+            ])
+            #expect(has == true)
+        }
+    }
+
+    @Test func testArrayListGrowth() throws {
+        // ArrayList — verifies object array creation and indexed access
+        try jniContext {
+            let listClass = try JClass(name: "java/util/ArrayList", systemClass: true)
+            let listInit = try #require(listClass.getMethodID(name: "<init>", sig: "()V"))
+            let add = try #require(listClass.getMethodID(name: "add", sig: "(Ljava/lang/Object;)Z"))
+            let getAt = try #require(listClass.getMethodID(name: "get", sig: "(I)Ljava/lang/Object;"))
+            let size = try #require(listClass.getMethodID(name: "size", sig: "()I"))
+
+            let list = try listClass.create(ctor: listInit, options: [], args: [])
+
+            // Add enough elements to trigger internal array resizing
+            let count: Int32 = 50
+            for i in 0..<count {
+                let _: Bool = try list.call(method: add, options: [], args: [
+                    "item-\(i)".toJavaParameter(options: []),
+                ])
+            }
+
+            let listSize: Int32 = try list.call(method: size, options: [], args: [])
+            #expect(listSize == count)
+
+            // Verify first and last elements
+            let first: String = try list.call(method: getAt, options: [], args: [JavaParameter(i: 0)])
+            #expect(first == "item-0")
+
+            let last: String = try list.call(method: getAt, options: [], args: [JavaParameter(i: count - 1)])
+            #expect(last == "item-\(count - 1)")
+        }
+    }
+
+    // MARK: - System properties (differ between Android and desktop JVMs)
+
+    @Test func testSystemProperties() throws {
+        try jniContext {
+            let systemClass = try JClass(name: "java/lang/System", systemClass: true)
+            let getProperty = try #require(systemClass.getStaticMethodID(name: "getProperty", sig: "(Ljava/lang/String;)Ljava/lang/String;"))
+
+            // file.separator: "/" on all Unix-like JVMs including Android
+            let fileSep: String = try systemClass.callStatic(method: getProperty, options: [], args: [
+                "file.separator".toJavaParameter(options: []),
+            ])
+            #expect(fileSep == "/")
+
+            // java.vm.name differs: "Dalvik" on Android, various on desktop
+            let vmName: String? = try systemClass.callStatic(method: getProperty, options: [], args: [
+                "java.vm.name".toJavaParameter(options: []),
+            ])
+            if isAndroid {
+                #expect(vmName?.contains("Dalvik") == true || vmName?.contains("Art") == true,
+                       "Expected Android VM name, got: \(vmName ?? "nil")")
+            } else {
+                #expect(vmName != nil, "Desktop JVM should report a VM name")
+            }
+        }
+    }
+
+    // MARK: - Threading and jniContext
+
+    @Test func testJniContextFromBackgroundThread() async throws {
+        // jniContext must attach/detach native threads — critical on Android where
+        // native threads are not automatically attached to ART
+        let result: Int32 = try await Task.detached {
+            try jniContext {
+                let integerClass = try JClass(name: "java/lang/Integer", systemClass: true)
+                let parseInt = try #require(integerClass.getStaticMethodID(name: "parseInt", sig: "(Ljava/lang/String;)I"))
+                let val: Int32 = try integerClass.callStatic(method: parseInt, options: [], args: [
+                    "99".toJavaParameter(options: []),
+                ])
+                return val
+            }
+        }.value
+        #expect(result == 99)
+    }
+
+    @Test func testConcurrentJniAccess() async throws {
+        // Multiple concurrent tasks using jniContext — exercises thread attach/detach
+        // and verifies no corruption under contention
+        try await withThrowingTaskGroup(of: Int32.self) { group in
+            for i: Int32 in 0..<10 {
+                group.addTask {
+                    try jniContext {
+                        let integerClass = try JClass(name: "java/lang/Integer", systemClass: true)
+                        let valueOf = try #require(integerClass.getStaticMethodID(name: "valueOf", sig: "(I)Ljava/lang/Integer;"))
+                        let intValue = try #require(integerClass.getMethodID(name: "intValue", sig: "()I"))
+
+                        let obj: JavaObjectPointer = try integerClass.callStatic(method: valueOf, options: [], args: [JavaParameter(i: i)])
+                        let val: Int32 = try obj.call(method: intValue, options: [], args: [])
+                        return val
+                    }
+                }
+            }
+            var results: Set<Int32> = []
+            for try await val in group {
+                results.insert(val)
+            }
+            #expect(results == Set(0..<10))
+        }
+    }
+
+    // MARK: - Monitor / synchronization
+
+    @Test func testMonitorEnterExit() throws {
+        // JNI monitors map to Java synchronized blocks — ART monitors have
+        // different internal implementations (thin locks vs fat locks)
+        jniContext {
+            let obj = "lock_object".toJavaObject(options: [])!
+            let enterResult = JNI.jni.monitorEnter(obj: obj)
+            #expect(enterResult == 0) // JNI_OK
+
+            // Re-entrant lock should succeed (Java monitors are reentrant)
+            let reenterResult = JNI.jni.monitorEnter(obj: obj)
+            #expect(reenterResult == 0)
+
+            let exitResult1 = JNI.jni.monitorExit(obj: obj)
+            #expect(exitResult1 == 0)
+
+            let exitResult2 = JNI.jni.monitorExit(obj: obj)
+            #expect(exitResult2 == 0)
+        }
+    }
+
+    // MARK: - JNI version and environment
+
+    @Test func testJNIVersion() throws {
+        jniContext {
+            let version = JNI.jni.version
+            // JNI 1.6 = 0x00010006
+            #expect(version >= 0x00010006, "JNI version should be at least 1.6")
+        }
+    }
+
+    // MARK: - Primitive wrapper boxing
+
+    @Test func testBooleanBoxing() throws {
+        try jniContext {
+            let boolClass = try JClass(name: "java/lang/Boolean", systemClass: true)
+            let valueOf = try #require(boolClass.getStaticMethodID(name: "valueOf", sig: "(Z)Ljava/lang/Boolean;"))
+            let boolValue = try #require(boolClass.getMethodID(name: "booleanValue", sig: "()Z"))
+
+            let trueObj: JavaObjectPointer = try boolClass.callStatic(method: valueOf, options: [], args: [JavaParameter(z: 1)])
+            let trueVal: Bool = try trueObj.call(method: boolValue, options: [], args: [])
+            #expect(trueVal == true)
+
+            let falseObj: JavaObjectPointer = try boolClass.callStatic(method: valueOf, options: [], args: [JavaParameter(z: 0)])
+            let falseVal: Bool = try falseObj.call(method: boolValue, options: [], args: [])
+            #expect(falseVal == false)
+        }
+    }
+
+    @Test func testFloatPrecision() throws {
+        // Float (32-bit) precision — ART and HotSpot must produce identical IEEE 754 results
+        try jniContext {
+            let floatClass = try JClass(name: "java/lang/Float", systemClass: true)
+            let floatInit = try #require(floatClass.getMethodID(name: "<init>", sig: "(F)V"))
+            let floatValue = try #require(floatClass.getMethodID(name: "floatValue", sig: "()F"))
+            let intBitsToFloat = try #require(floatClass.getStaticMethodID(name: "intBitsToFloat", sig: "(I)F"))
+
+            // Smallest positive float
+            let tinyObj = try floatClass.create(ctor: floatInit, options: [], args: [JavaParameter(f: Float.leastNonzeroMagnitude)])
+            let tinyVal: Float = try tinyObj.call(method: floatValue, options: [], args: [])
+            #expect(tinyVal == Float.leastNonzeroMagnitude)
+
+            // Float from raw bits — exercises exact bit-level representation
+            let piVal: Float = try floatClass.callStatic(method: intBitsToFloat, options: [], args: [
+                JavaParameter(i: 0x40490FDB) // IEEE 754 representation of ~pi
+            ])
+            #expect(abs(piVal - Float.pi) < 1e-6)
+        }
+    }
+
+    // MARK: - String interning (HotSpot vs ART divergence)
+
+    @Test func testStringIntern() throws {
+        // String.intern() behavior — HotSpot interns to a PermGen/Metaspace pool,
+        // ART uses a different interning mechanism. Both must return the same
+        // object for equal interned strings per the JLS.
+        try jniContext {
+            let stringClass = try JClass(name: "java/lang/String", systemClass: true)
+            let intern = try #require(stringClass.getMethodID(name: "intern", sig: "()Ljava/lang/String;"))
+
+            let s1 = "intern_test_xyz".toJavaObject(options: [])!
+            let s2 = "intern_test_xyz".toJavaObject(options: [])!
+
+            let interned1: JavaObjectPointer = try s1.call(method: intern, options: [], args: [])
+            let interned2: JavaObjectPointer = try s2.call(method: intern, options: [], args: [])
+
+            // Interned strings with same content must be the same object
+            let same: Bool = JNI.jni.withEnv { jni, env in jni.IsSameObject(env, interned1, interned2) == 1 }
+            #expect(same, "Interned strings with same content should be identical objects")
+        }
+    }
+
+    // MARK: - Regex (Android uses ICU, desktop uses java.util.regex)
+
+    @Test func testRegexEngine() throws {
+        // Android's Pattern implementation uses ICU under the hood, which can have
+        // subtle differences in Unicode category matching compared to OpenJDK
+        try jniContext {
+            let patternClass = try JClass(name: "java/util/regex/Pattern", systemClass: true)
+            let compile = try #require(patternClass.getStaticMethodID(name: "compile", sig: "(Ljava/lang/String;)Ljava/util/regex/Pattern;"))
+            let matcher = try #require(patternClass.getMethodID(name: "matcher", sig: "(Ljava/lang/CharSequence;)Ljava/util/regex/Matcher;"))
+
+            let matcherClass = try JClass(name: "java/util/regex/Matcher", systemClass: true)
+            let matches = try #require(matcherClass.getMethodID(name: "matches", sig: "()Z"))
+            let find = try #require(matcherClass.getMethodID(name: "find", sig: "()Z"))
+
+            // Basic pattern
+            let pattern: JavaObjectPointer = try patternClass.callStatic(method: compile, options: [], args: [
+                "\\d+".toJavaParameter(options: []),
+            ])
+            let m: JavaObjectPointer = try pattern.call(method: matcher, options: [], args: [
+                ("12345" as String).toJavaParameter(options: []),
+            ])
+            let fullMatch: Bool = try m.call(method: matches, options: [], args: [])
+            #expect(fullMatch)
+
+            // Unicode letter matching — \p{L} should match across scripts
+            let uniPattern: JavaObjectPointer = try patternClass.callStatic(method: compile, options: [], args: [
+                "\\p{L}+".toJavaParameter(options: []),
+            ])
+            let uniMatcher: JavaObjectPointer = try uniPattern.call(method: matcher, options: [], args: [
+                ("日本語".toJavaParameter(options: [])),
+            ])
+            let uniMatch: Bool = try uniMatcher.call(method: matches, options: [], args: [])
+            #expect(uniMatch, "\\p{L} should match CJK characters on both ART and HotSpot")
+
+            // Emoji — \p{Emoji} is supported on newer JVMs but may behave differently
+            // Just test that find() works with a mixed string (non-crashing is the main assertion)
+            let mixedPattern: JavaObjectPointer = try patternClass.callStatic(method: compile, options: [], args: [
+                "[a-z]+".toJavaParameter(options: []),
+            ])
+            let mixedMatcher: JavaObjectPointer = try mixedPattern.call(method: matcher, options: [], args: [
+                "🎵hello🎶".toJavaParameter(options: []),
+            ])
+            let found: Bool = try mixedMatcher.call(method: find, options: [], args: [])
+            #expect(found, "Should find 'hello' in emoji-surrounded string")
+        }
+    }
+
+    // MARK: - Charset encoding (Android defaults can differ)
+
+    @Test func testCharsetDefaultEncoding() throws {
+        // Android historically defaulted to UTF-8, while older desktop JVMs used
+        // platform-specific encodings. Modern JDK 18+ also defaults to UTF-8.
+        try jniContext {
+            let charsetClass = try JClass(name: "java/nio/charset/Charset", systemClass: true)
+            let defaultCharset = try #require(charsetClass.getStaticMethodID(name: "defaultCharset", sig: "()Ljava/nio/charset/Charset;"))
+            let charsetName = try #require(charsetClass.getMethodID(name: "name", sig: "()Ljava/lang/String;"))
+
+            let cs: JavaObjectPointer = try charsetClass.callStatic(method: defaultCharset, options: [], args: [])
+            let name: String = try cs.call(method: charsetName, options: [], args: [])
+
+            if isAndroid {
+                #expect(name == "UTF-8", "Android should default to UTF-8")
+            }
+            // On desktop, just verify it returns a valid charset name
+            #expect(!name.isEmpty)
         }
     }
 }

--- a/Tests/SwiftJNITests/SwiftJNITests.swift
+++ b/Tests/SwiftJNITests/SwiftJNITests.swift
@@ -2,18 +2,29 @@
 @testable import SwiftJNI
 import Testing
 
+
+#if os(Android)
+let isAndroid = true
+#else
+let isAndroid = false
+#endif
+
 @Suite struct SwiftJNITests {
-    @Test func testSwiftJNI() throws {
-        try JNI.attachJVM(launch: true)
+    init() throws {
+        try JNI.attachJVM(launch: !isAndroid)
+    }
 
-        let integerClass = try JClass(name: "java/lang/Integer", systemClass: true)
+    @Test func testSwiftJNI() async throws {
+        try jniContext {
+            let integerClass = try JClass(name: "java/lang/Integer", systemClass: true)
 
-        let integerInit = try #require(integerClass.getMethodID(name: "<init>", sig: "(I)V"))
-        let integerInstance = try integerClass.create(ctor: integerInit, options: [], args: [JavaParameter(i: .max)])
+            let integerInit = try #require(integerClass.getMethodID(name: "<init>", sig: "(I)V"))
+            let integerInstance = try integerClass.create(ctor: integerInit, options: [], args: [JavaParameter(i: .max)])
 
-        let integerIntValue = try #require(integerClass.getMethodID(name: "intValue", sig: "()I"))
-        let i: Int32 = try integerInstance.call(method: integerIntValue, options: [], args: [])
+            let integerIntValue = try #require(integerClass.getMethodID(name: "intValue", sig: "()I"))
+            let i: Int32 = try integerInstance.call(method: integerIntValue, options: [], args: [])
 
-        #expect(i == 2147483647, "Int.MAX_VALUE should be 32-bit")
+            #expect(i == 2147483647, "Int.MAX_VALUE should be 32-bit")
+        }
     }
 }


### PR DESCRIPTION
This PR adds a `SWIFT_JAVA_JNI_CORE` constant, (temporarily) controlled by a build environment variable `SWIFT_JAVA_JNI_CORE`, that adds a dependency on https://github.com/swiftlang/swift-java-jni-core.git and retroactively conforms `JObject` to `JavaValue`, which will enable interoperability between Skip's bridged Kotlin types and SwiftJava `@JavaClass` values.